### PR TITLE
Riley/master changes

### DIFF
--- a/algorithms/scot.py
+++ b/algorithms/scot.py
@@ -44,15 +44,15 @@ def scot(mdp, w, s_start=None, m=None, H=None, seed=None, verbose=False):
     BEC = np.empty((mdp.nS*mdp.nA, w.shape[0]))
 
     # compute BEC for teacher policy
-    for a in range(mdp.nA):
-        BEC[a*mdp.nS:(a+1)*mdp.nS] = mu - mu_sa[:, a]
-    # BEC = np.empty((mdp.nS*(mdp.nA-1), w.shape[0]))
-    # i = 0
-    # for s in range(mdp.nS):
-    #     for a in range(mdp.nA):
-    #         if a != teacher_pol_det[s]:
-    #             BEC[i] = mu[s] - mu_sa[s, a]
-    #             i += 1
+    # for a in range(mdp.nA):
+    #     BEC[a*mdp.nS:(a+1)*mdp.nS] = mu - mu_sa[:, a]
+    BEC = np.empty((mdp.nS*(mdp.nA-1), w.shape[0]))
+    i = 0
+    for s in range(mdp.nS):
+        for a in range(mdp.nA):
+            if a != teacher_pol_det[s]:
+                BEC[i] = mu[s] - mu_sa[s, a]
+                i += 1
 
     # remove trivial, duplicate, and redundant half-space constraints
     BEC = refineBEC(w, BEC)
@@ -145,8 +145,8 @@ def compute_traj_BEC(traj, mu, mu_sa, mdp, w):
         # COULD REMOVE REDUNDANT SA-PAIRS HERE WITH A SET OF (S, A, R, S_NEW) TUPLES
         (s, a, r, s_new) = traj[i]
         for b in range(mdp.nA):
-            # if b != a:
-            BEC_traj_np[i * mdp.nA + b] = mu[s] - mu_sa[s, b]
+            if b != a:
+                BEC_traj_np[i * mdp.nA + b] = mu[s] - mu_sa[s, b]
             # if b == a:
             #     print(mu[s] - mu_sa[s, b])
 

--- a/env.py
+++ b/env.py
@@ -8,7 +8,7 @@ class Grid(object):
     def __init__(self, height:int, width:int, gamma:float, white_r:float=None,
                 features_sq:List[Dict]=None, gen_features:Union[List[List], Any]=None, n_features:int=None,
                 noise:float=0.0, weights=None,
-                start_corner=True, start_dist=None, end_pos:Tuple=None, one_hot=False):
+                start_corner=True, start_dist=None, end_pos:Tuple=None, one_hot=False, verbose=True):
         '''
         Initialize Grid environment
 
@@ -77,7 +77,8 @@ class Grid(object):
 
                 self.board = np.array([[self.reward(self.grid_to_state((h, w)))
                                         for w in range(width)] for h in range(height)], dtype=np.float32)
-                print(self.board)
+                if verbose == True:
+                    print(self.board)
             else:
                 self.s_features = [np.array(gen_features[s]) for s in range(self.nS)]
             self.board = np.array([[self.reward(self.grid_to_state((h, w)))

--- a/main.py
+++ b/main.py
@@ -44,13 +44,21 @@ def get_env():
 
     return test
 
+
 def main():
-    test = get_env() # default BrownNiekum()
+    seed = 2
+    np.random.seed(seed)
+    test = get_env()  # default BrownNiekum()
     test.env.render()
+    # for i in range(50, 100):
+    #     np.random.seed(i)
+    #     test = get_env()  # default BrownNiekum()
+    #     # test.env.render()
+    #     print("i")
+    #     print(i)
+    #     trajs = scot(test.env, test.env.weights, seed=i+1, verbose=False)
 
-    np.random.seed(2)
-    trajs = scot(test.env, test.env.weights, verbose=True)
-
+    trajs = scot(test.env, test.env.weights, seed=seed, verbose=False)
     # student's inferred reward function from the trajectories from SCOT
     r_weights = max_likelihood_irl(trajs, test.env, step_size=0.2, eps=1.0e-03, max_steps=1000, verbose=True)
 

--- a/main.py
+++ b/main.py
@@ -53,7 +53,6 @@ def main():
     # for i in range(50, 100):
     #     np.random.seed(i)
     #     test = get_env()  # default BrownNiekum()
-    #     # test.env.render()
     #     print("i")
     #     print(i)
     #     trajs = scot(test.env, test.env.weights, seed=i+1, verbose=False)

--- a/tests.py
+++ b/tests.py
@@ -204,7 +204,7 @@ class BrownNiekum(object):
 
         # tests of explicit arbitrary feature inputs on a state-by-state basis
         self.env = Grid(9, 9, 0.9, gen_features="random", n_features=8, weights="random",
-                        noise=0.0, start_corner=False)
+                        noise=0.0, start_corner=False, verbose=False)
 
         self.policy = self.init_policy()
         self.agent = Agent(self.policy, self.env.nS, self.env.nA)
@@ -212,6 +212,6 @@ class BrownNiekum(object):
 
     def init_policy(self):
         _, policy = value_iteration(self.env)
-        print('Policy from VI: {}'.format(policy))
+        # print('Policy from VI: {}'.format(policy))
         policy = det2stoch_policy(policy, self.env.nS, self.env.nA)
         return policy

--- a/util.py
+++ b/util.py
@@ -86,7 +86,7 @@ def baseline(mdp, s_start, max_demonstrations=50):
                 a lists of (s, a, r, s') experience tuples
     '''
     # choose random number of demonstrations
-    num_demonstrations = random.randint(1, max_demonstations)
+    num_demonstrations = random.randint(1, max_demonstrations)
 
     # loop through and generate those random demonstrations
     D = []


### PR DESCRIPTION
some changes to SCOT. some stochastic bugs are still present that we ignore by terminating the set cover loop if the set of candidate trajectories is emptied. After testing with several (~100+) random initializations (see testing scheme in main()), it seems like only one (and once, two) BEC constraints are not covered by SCOT at any time. It seems like the uncovered constraints are trivial (some floating point errors seem to be popping up...)